### PR TITLE
`callback_url` should be redefined to let namecheap use google analytics tags in their params

### DIFF
--- a/lib/omniauth/namecheap/version.rb
+++ b/lib/omniauth/namecheap/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Namecheap
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.1.1'.freeze
   end
 end

--- a/lib/omniauth/strategies/namecheap.rb
+++ b/lib/omniauth/strategies/namecheap.rb
@@ -10,6 +10,10 @@ module OmniAuth
                               token_url:     '/apps/sso/api/token',
                               me_url:        '/apps/sso/api/resource/user'
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       # These are called after authentication has succeeded. If
       # possible, you should try to set the UID without making
       # additional calls (if the user id is returned with the token


### PR DESCRIPTION
Hi Rachel!